### PR TITLE
Projection

### DIFF
--- a/projector_batch.py
+++ b/projector_batch.py
@@ -1,0 +1,270 @@
+import argparse
+import math
+import os, glob
+
+import numpy as np
+import random
+import torch
+from torch import optim
+from torch.nn import functional as F
+from torchvision import transforms
+from PIL import Image
+from tqdm import tqdm
+
+import lpips
+from model_new import Generator
+from dataset import TestDataset, PadTransform
+from torch.utils.data import DataLoader
+
+
+def noise_regularize(noises):
+    loss = 0
+
+    for noise in noises:
+        size = noise.shape[2]
+
+        while True:
+            loss = (
+                loss
+                + (noise * torch.roll(noise, shifts=1, dims=3)).mean().pow(2)
+                + (noise * torch.roll(noise, shifts=1, dims=2)).mean().pow(2)
+            )
+
+            if size <= 8:
+                break
+
+            noise = noise.reshape([-1, 1, size // 2, 2, size // 2, 2])
+            noise = noise.mean([3, 5])
+            size //= 2
+
+    return loss
+
+
+def noise_normalize_(noises):
+    for noise in noises:
+        mean = noise.mean()
+        std = noise.std()
+
+        noise.data.add_(-mean).div_(std)
+
+
+def get_lr(t, initial_lr, rampdown=0.25, rampup=0.05):
+    lr_ramp = min(1, (1 - t) / rampdown)
+    lr_ramp = 0.5 - 0.5 * math.cos(lr_ramp * math.pi)
+    lr_ramp = lr_ramp * min(1, t / rampup)
+
+    return initial_lr * lr_ramp
+
+
+def latent_noise(latent, strength):
+    noise = torch.randn_like(latent) * strength
+
+    return latent + noise
+
+
+def make_image(tensor):
+    return (
+        tensor.detach()
+        .clamp_(min=-1, max=1)
+        .add(1)
+        .div_(2)
+        .mul(255)
+        .type(torch.uint8)
+        .permute(0, 2, 3, 1)
+        .to("cpu")
+        .numpy()
+    )
+
+def fix_seed(random_seed):
+    """
+    fix seed to control any randomness from a code 
+    (enable stability of the experiments' results.)
+    """
+    torch.manual_seed(random_seed)
+    torch.cuda.manual_seed(random_seed)
+    torch.cuda.manual_seed_all(random_seed)  # if use multi-GPU
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    np.random.seed(random_seed)
+    random.seed(random_seed)
+
+
+if __name__ == "__main__":
+    device = "cuda"
+
+    parser = argparse.ArgumentParser(
+        description="Image projector to the generator latent spaces"
+    )
+    parser.add_argument(
+        "--batch", type=int, required=True
+    )
+    parser.add_argument(
+        "--ckpt", type=str, default="/home/data/Labels4Free/checkpoint/stylegan2-car-config-f.pt", help="path to the model checkpoint"
+    )
+    parser.add_argument(
+        "--size", type=int, default=256, help="output image sizes of the generator"
+    )
+    parser.add_argument(
+        "--lr_rampup",
+        type=float,
+        default=0.05,
+        help="duration of the learning rate warmup",
+    )
+    parser.add_argument(
+        "--lr_rampdown",
+        type=float,
+        default=0.25,
+        help="duration of the learning rate decay",
+    )
+    parser.add_argument("--lr", type=float, default=0.1, help="learning rate")
+    parser.add_argument(
+        "--noise", type=float, default=0.05, help="strength of the noise level"
+    )
+    parser.add_argument(
+        "--noise_ramp",
+        type=float,
+        default=0.75,
+        help="duration of the noise level decay",
+    )
+    parser.add_argument("--step", type=int, default=1000, help="optimize iterations")
+    parser.add_argument(
+        "--noise_regularize",
+        type=float,
+        default=1e5,
+        help="weight of the noise regularization",
+    )
+    parser.add_argument("--mse", type=float, default=0, help="weight of the mse loss")
+    parser.add_argument(
+        "--w_plus",
+        action="store_true",
+        help="allow to use distinct latent codes to each layers",
+    )
+    parser.add_argument("--save_dir", type=str, default="test/proj_results")
+    parser.add_argument(
+        "--root", type=str, default="/home/data/Labels4Free/top148"
+    )
+
+    args = parser.parse_args()
+
+    fix_seed(0)
+
+    n_mean_latent = 10000
+
+    resize = min(args.size, 256) # 무조건 최대 256으로 resize되는 형태임. (그것보다 큰 사이즈 들어와도 256으로 squeeze됨)
+
+    # transform = transforms.Compose(
+    #     [
+    #         transforms.Resize((resize, resize)),
+    #         #transforms.CenterCrop(resize),
+    #         transforms.ToTensor(),
+    #         transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
+    #     ]
+    # )
+
+    # data loading
+    transform = PadTransform(resize)
+    dataset = TestDataset(args.root, transform)
+    dataloader = DataLoader(dataset, batch_size=args.batch, num_workers=4, pin_memory=True)
+
+    g_ema = Generator(args.size, 512, 8)
+    g_ema.load_state_dict(torch.load(args.ckpt)["g_ema"], strict=False)
+    g_ema.eval()
+    g_ema = g_ema.to(device)
+
+    with torch.no_grad():
+        noise_sample = torch.randn(n_mean_latent, 512, device=device)
+        latent_out = g_ema.style(noise_sample)
+
+        latent_mean = latent_out.mean(0)
+        latent_std = ((latent_out - latent_mean).pow(2).sum() / n_mean_latent) ** 0.5
+
+    percept = lpips.LPIPS(
+        net="vgg"
+    ).to(device)
+
+    for batch_idx, img in enumerate(dataloader):
+        
+        print(f"Batch {batch_idx}")
+
+        img = img.to(device)
+
+        noises = list(map(lambda x: x.repeat(img.shape[0], 1, 1, 1).normal_(), g_ema.make_noise()))
+        latent_in = latent_mean.detach().clone().unsqueeze(0).repeat(img.shape[0], 1)
+
+        if args.w_plus:
+            latent_in = latent_in.unsqueeze(1).repeat(1, g_ema.n_latent, 1)
+        
+        latent_in.requires_grad = True
+
+        for noise in noises:
+            noise.requires_grad = True
+
+        optimizer = optim.Adam([latent_in] + noises, lr=args.lr)
+
+        pbar = tqdm(range(args.step))
+        latent_path = []
+
+        for i in pbar:
+            t = i / args.step
+            lr = get_lr(t, args.lr)
+            optimizer.param_groups[0]['lr'] = lr
+            noise_strength = latent_std * args.noise * max(0, 1-t/args.noise_ramp) ** 2
+            latent_n = latent_noise(latent_in, noise_strength.item())
+
+            img_gen, _ = g_ema([latent_n], input_is_latent=True, noise=noises)
+
+            batch, channel, height, width = img_gen.shape
+
+            if height > 256:
+                factor = height // 256
+
+                img_gen = img_gen.reshape(
+                    batch, channel, height // factor, factor, width // factor, factor
+                )
+                img_gen = img_gen.mean([3, 5])
+
+            p_loss = percept(img_gen, img).sum()
+            n_loss = noise_regularize(noises)
+            mse_loss = F.mse_loss(img_gen, img)
+
+            loss = p_loss + args.noise_regularize * n_loss + args.mse * mse_loss
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            noise_normalize_(noises)
+
+            pbar.set_description(
+                (
+                    f"perceptual: {p_loss.item():.4f}; noise regularize: {n_loss.item():.4f};"
+                    f" mse: {mse_loss.item():.4f}; lr: {lr:.4f}"
+                )
+            )
+        
+        filename = os.path.join(args.save_dir, os.path.splitext(os.path.basename(args.root))[0] + f"_batch{batch_idx}.pt")
+
+        img_ar = make_image(img_gen)
+
+        result_file = {}
+        file_idx = batch_idx*args.batch
+
+        save_dir = os.path.join(args.save_dir, f"batch_{batch_idx}")
+        os.makedirs(save_dir, exist_ok=True)
+
+        for i, input_name in enumerate(dataset.file_list[file_idx:file_idx+args.batch]):
+            noise_single = []
+            for noise in noises:
+                noise_single.append(noise[i : i + 1])
+
+            result_file[input_name] = {
+                "img": img_gen[i],
+                "latent": latent_in[i],
+                "noise": noise_single,
+            } # 애초에 경로 내에 여러 test 이미지가 있을 경우에 하나의 pt 파일에 저장되는 형식인 듯? 그건 참 좋다.
+
+            img_name = os.path.splitext(os.path.basename(input_name))[0] + "-project.png"
+            pil_img = Image.fromarray(img_ar[i])
+            pil_img.save(os.path.join(save_dir, img_name))
+        
+        torch.save(result_file, filename)


### PR DESCRIPTION
## Dataset
**- PadTransform 추가**
resize & center crop을 적용할 경우 차의 형태가 완전히 보존되지 않아서 projection 성능이 많이 떨어지는 문제가 있었음. 따라서 원본 형태를 온전히 보존하기 위해서 PadTransforms를 추가하여, 이미지의 너비,높이 중 길이가 긴 쪽을 원하는 size에 맞추고 남는 부분을 padding을 통해 채워줌으로써 square 형태를 유지할 수 있도록 함.

## Projection
**-Projector_batch.py 추가**
기존의 projector.py의 경우, 여러 이미지에 대한 projection을 수행하는 데에는 적합하지 않았음. NVIDIA A5000 24GB 기준, 512의 사이즈에서 16장의 이미지만 gpu에 올릴 수 있는 상태였는데, list로 이미지 텐서를 만드는 것이 구현되어 있어서 gpu 메모리에 할당된 데이터가 해제되는 과정이 제대로 이루어지지 않았음. 따라서 다음 배치에 대한 projection을 수행할 때에 GPU OOM 문제가 발생함. 이를 해결하기 위해 dataset.py에 TestDataset을 구축하고, projector_batch.py 파일을 만들어서 배치 단위로 projection을 효율적으로 수행할 수 있도록 DataLoader를 통해 데이터를 뿌려줄 수 있도록 함.
또한, 불필요하게 generator를 통과하고 latent code를 담고 있는 부분을 삭제함 (이 부분이 해결안이었을 수도 있겠다는 생각).