### PR TITLE
Flower Segmentation

### DIFF
--- a/model_new.py
+++ b/model_new.py
@@ -814,11 +814,12 @@ class bg_extractor_repro(nn.Module):
         if self.image_size == 1024:
              self.tensor_resolutions = [ 512, 512, 512, 512, 256, 256,  128, 128, 64, 64, 32, 32]
 
-        elif self.image_size == 512:
+        # elif self.image_size == 512:
+        else:
             self.tensor_resolutions = [ 512,  512,  512, 512,  512,  512,  256, 256, 128, 128, 64, 64 ]
 
-        else:
-             self.tensor_resolutions = [ 512, 512,  512,  512, 512, 512,  512,  512,  256, 256, 128, 128]
+        # else:
+        #      self.tensor_resolutions = [ 512, 512,  512,  512, 512, 512,  512,  512,  256, 256, 128, 128]
 
         self.image_resolutions = [ 16, 32, 64, 128, 256, 512, 1024]
         
@@ -889,7 +890,9 @@ class bg_extractor(nn.Module):
             self.tensor_resolutions = [ 512,  512,  512,  256,  128,  64]
 
         else:
-            self.tensor_resolutions = [ 512, 512,  512,  512,  256,  128]
+            # self.tensor_resolutions = [ 512, 512,  512,  512,  256,  128] -> 이렇게 하면 에러 남.. (@ 256)
+            self.tensor_resolutions = [ 512, 512,  512,  256,  128,  64]
+
 
         self.upsample_fns = [nn.Upsample(size=(res, res), mode='bicubic', align_corners=True) for res in self.image_resolutions if res >= min_res*2]
         self.upsample_fns = nn.ModuleList(self.upsample_fns)

--- a/train.py
+++ b/train.py
@@ -19,7 +19,7 @@ except ImportError:
     wandb = None
 
 from model_new import Generator, Discriminator, bg_extractor_repro, bg_extractor
-from dataset import MultiResolutionDataset
+from dataset import MultiResolutionDataset, TestDataset
 from distributed import (
     get_rank,
     synchronize,
@@ -378,6 +378,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="StyleGAN2 Alpha Network trainer")
 
     parser.add_argument("path", type=str, help="path to the lmdb dataset")
+    parser.add_argument("--use_lmdb", action="store_true", help="flag of whether to use lmdb dataset or not")
     parser.add_argument(
         "--iter", type=int, default=1001, help="total training iterations"
     )
@@ -548,7 +549,7 @@ if __name__ == "__main__":
 
     g_reg_ratio = args.g_reg_every / (args.g_reg_every + 1)
     d_reg_ratio = args.d_reg_every / (args.d_reg_every + 1)
-    parm_ =  list(alphanet_model.parameters())
+    parm_ =  list(alphanet_model.parameters()) # 왜 굳이 list로 해서 넣어줄까..?
     g_optim = optim.Adam(
         parm_,
         lr=args.lr * g_reg_ratio,
@@ -630,8 +631,12 @@ if __name__ == "__main__":
             transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5), inplace=True),
         ]
     )
+
     print("Building Dataset...")
-    dataset = MultiResolutionDataset(args.path, transform, args.size)
+    if args.use_lmdb:
+        dataset = MultiResolutionDataset(args.path, transform, args.size)
+    else:
+        dataset = TestDataset(args.path, transform)
     print("Dataset Built!")
 
     loader = data.DataLoader(


### PR DESCRIPTION
## 기존 코드 behavior
1. car dataset에 너무 의존적 → 데이터셋 불러오는 부분이 LSUN-Car가 저장되어 있는 방식인 lmdb dataset에만 의존되어 있음. 
2. model 구조에서 generated output size가 512가 아닌 경우 (flower 같은 경우에는 256으로 학습이 된 상태), channel multiplier를 1로 설정해줬음에도 불구하고, shape mismatch error가 발생. 

## 해결
1. dataset 이름과 lmdb를 사용할 것인지에 따라서 lmdb를 사용하지 않게 되면, TestDataset이라는  stylegan 학습을 위한 torch dataset을 불러와서 해당 데이터셋 클래스를 사용하도록 함.
2. 일단은 하드코딩으로 에러가 나는 layer에서의 채널 차원을 128에서 끝나는 게 아니라 64에서 끝나도록 수정해줌.

## 보완할 점
2번 같은 경우에는 정확히 어떤 문제가 있는 건지 더 파악을 해서 좀 더 유연하게 인자 대응을 할 수 있도록 코드 수정을 거쳐야될 듯함.
